### PR TITLE
Update to Minecraft 1.21.10

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -20,12 +20,10 @@ jobs:
         run: ./gradlew build
       - name: Extract Mod Version
         run: |
-             VERSION=$(grep "mod_version" gradle.properties | cut -d'=' -f2)
-             echo "VERSION=$VERSION" >> $GITHUB_ENV
+            VERSION=$(grep "mod_version" gradle.properties | cut -d'=' -f2 | cut -d'-' -f1)
+            echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Get Fabric Jar Filename
         run: echo "NAME=jefff-mod-${{ env.VERSION }}-${{ env.MINECRAFT_VERSION }}" >> $GITHUB_ENV
-      - name: Rename Output File
-        run: mv ./build/libs/*.jar ./build/libs/${{ env.NAME }}.jar
       - name: Release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -2,10 +2,10 @@ name: Publish Development Build
 on:
     push:
         branches:
-            - "1.21.8"
+            - "1.21.10"
 
 env:
-  MINECRAFT_VERSION: "1.21.8"
+  MINECRAFT_VERSION: "1.21.10"
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jeff mod (For minecraft 1.21.1, 1.21.4, 1.21.5, 1.21.8)
+# jeff mod (For minecraft 1.21.1, 1.21.4, 1.21.5, 1.21.8, 1.21.10)
 #### Make an issue or DM me on discord `0x658` with any questions (Check the FAQ first)
 #### Pull Requests are welcome, please make them to the 1.21.1 branch.
 #### Check the [Wiki](https://github.com/miles352/meteor-stashhunting-addon/wiki) for a full list of features and options.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,28 +2,28 @@ org.gradle.jvmargs=-Xmx2G
 
 # Fabric Properties (https://fabricmc.net/develop)
 
-minecraft_version=1.21.8
-yarn_mappings=1.21.8+build.1
+minecraft_version=1.21.10
+yarn_mappings=1.21.10+build.2
 loader_version=0.17.3
 
 # Mod Properties
-mod_version=0.16.7
+mod_version=0.16.7-1-21.10
 maven_group=com.example
 archives_base_name=jefff-mod
 
 # Dependencies
 
 # Meteor (https://maven.meteordev.org)
-meteor_version=1.21.8-SNAPSHOT
+meteor_version=1.21.10-SNAPSHOT
 
 # Baritone (https://maven.meteordev.org)
-baritone_version=1.21.8-SNAPSHOT
+baritone_version=1.21.10-SNAPSHOT
 
 # XaeroPlus
-xaeroplus_version=2.29.0+fabric-1.21.8
+xaeroplus_version=2.29.0+fabric-1.21.10
 
 # XaeroWorldmap
-xaeros_worldmap_version=1.39.13_Fabric_1.21.8
+xaeros_worldmap_version=1.39.17_Fabric_1.21.9
 
 # XaeroMinimap
-xaeros_minimap_version=25.2.16_Fabric_1.21.8
+xaeros_minimap_version=25.2.15_Fabric_1.21.9

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ yarn_mappings=1.21.10+build.2
 loader_version=0.17.3
 
 # Mod Properties
-mod_version=0.16.7-1-21.10
+mod_version=0.16.7-1.21.10
 maven_group=com.example
 archives_base_name=jefff-mod
 

--- a/src/main/java/com/stash/hunt/mixin/KeyBindingMixin.java
+++ b/src/main/java/com/stash/hunt/mixin/KeyBindingMixin.java
@@ -16,7 +16,7 @@ public abstract class KeyBindingMixin {
 
     @Final
     @Shadow
-    private String translationKey;
+    private String id;
 
     @Unique
     ElytraFlyPlusPlus efly = null;
@@ -26,7 +26,7 @@ public abstract class KeyBindingMixin {
     {
         // setting it beforehand caused a crash because meteor wasnt loaded yet
         efly = efly == null ? Modules.get().get(ElytraFlyPlusPlus.class) : efly;
-        if (efly != null && efly.isActive() && efly.enabled() && translationKey.equals("key.forward"))
+        if (efly != null && efly.isActive() && efly.enabled() && id.equals("key.forward"))
         {
             cir.setReturnValue(true);
         }

--- a/src/main/java/com/stash/hunt/modules/AutoLogPlus.java
+++ b/src/main/java/com/stash/hunt/modules/AutoLogPlus.java
@@ -240,7 +240,7 @@ public class AutoLogPlus extends Module
         }
         if (logPosition.get())
         {
-            double distanceToTarget = mc.player.getPos().multiply(1,0,1).distanceTo(position.get().toCenterPos().multiply(1,0,1));
+            double distanceToTarget = mc.player.getEntityPos().multiply(1,0,1).distanceTo(position.get().toCenterPos().multiply(1,0,1));
             if (distanceToTarget < distance.get())
             {
                 logOut("Player was within " + distanceToTarget + " blocks of the target position.", true);

--- a/src/main/java/com/stash/hunt/modules/BetterStashFinder.java
+++ b/src/main/java/com/stash/hunt/modules/BetterStashFinder.java
@@ -337,7 +337,7 @@ public class BetterStashFinder extends Module
                     else
                     {
                         String message = "Found stash at " + chunk.x + ", " + chunk.z + ".";
-                        new Thread(() -> sendWebhook(webhookLink.get(), title, message, ping.get() ? discordId.get() : null, mc.player.getGameProfile().getName())).start();
+                        new Thread(() -> sendWebhook(webhookLink.get(), title, message, ping.get() ? discordId.get() : null, mc.player.getGameProfile().name())).start();
                     }
                 }
 
@@ -721,6 +721,6 @@ public class BetterStashFinder extends Module
         {
             if (disableOnTeleport.get() && mc.player.squaredDistanceTo(lastPosition) > 16 * 16) this.toggle();
         }
-        lastPosition = mc.player.getPos();
+        lastPosition = mc.player.getEntityPos();
     }
 }

--- a/src/main/java/com/stash/hunt/modules/DiscordNotifs.java
+++ b/src/main/java/com/stash/hunt/modules/DiscordNotifs.java
@@ -162,7 +162,7 @@ public class DiscordNotifs extends Module
                     if (!playersInRange.contains(playerEntity.getGameProfile()))
                     {
                         playersInRange.add(playerEntity.getGameProfile());
-                        handleMessage(playerEntity.getGameProfile().getName() + " has entered visual range!", MessageType.PLAYER_RANGE);
+                        handleMessage(playerEntity.getGameProfile().name() + " has entered visual range!", MessageType.PLAYER_RANGE);
                     }
                 }
             }
@@ -171,10 +171,10 @@ public class DiscordNotifs extends Module
         // Check for players leaving range
         for (GameProfile profile : playersInRange)
         {
-            if (!uuidsCurrentlyInRange.contains(profile.getId()))
+            if (!uuidsCurrentlyInRange.contains(profile.id()))
             {
                 playersInRange.remove(profile);
-                handleMessage(profile.getName() + " has left visual range!", MessageType.PLAYER_RANGE);
+                handleMessage(profile.name() + " has left visual range!", MessageType.PLAYER_RANGE);
             }
         }
     }

--- a/src/main/java/com/stash/hunt/modules/ElytraFlyPlusPlus.java
+++ b/src/main/java/com/stash/hunt/modules/ElytraFlyPlusPlus.java
@@ -261,12 +261,12 @@ public class ElytraFlyPlusPlus extends Module {
         paused = false;
         waitingForChunksToLoad = false;
         elytraToggled = false;
-        lastPos = mc.player.getPos();
-        lastUnstuckPos = mc.player.getPos();
+        lastPos = mc.player.getEntityPos();
+        lastUnstuckPos = mc.player.getEntityPos();
         stuckTimer = 0;
 
         // I don't know any other way to fix this stupid shit
-        if (bounce.get() && mc.player.getPos().multiply(1, 0, 1).length() >= 100)
+        if (bounce.get() && mc.player.getEntityPos().multiply(1, 0, 1).length() >= 100)
         {
             if (BaritoneAPI.getProvider().getPrimaryBaritone().getElytraProcess().currentDestination() == null)
             {
@@ -313,7 +313,7 @@ public class ElytraFlyPlusPlus extends Module {
 
         if (lastPos != null)
         {
-            double speedBps = mc.player.getPos().subtract(lastPos).multiply(20, 0, 20).length();
+            double speedBps = mc.player.getEntityPos().subtract(lastPos).multiply(20, 0, 20).length();
 
             Timer timer = Modules.get().get(Timer.class);
             if (timer.isActive()) {
@@ -330,7 +330,7 @@ public class ElytraFlyPlusPlus extends Module {
             }
         }
 
-        lastPos = mc.player.getPos();
+        lastPos = mc.player.getEntityPos();
     }
 
     @Override
@@ -410,10 +410,10 @@ public class ElytraFlyPlusPlus extends Module {
             else
             {
                 stuckTimer = 0;
-                lastUnstuckPos = mc.player.getPos();
+                lastUnstuckPos = mc.player.getEntityPos();
             }
 
-            if (highwayObstaclePasser.get() && mc.player.getPos().length() > 100 && // > 100 check needed bc server sends queue coordinates when joining in first tick causing goal coordinates to be set to (0, 0)
+            if (highwayObstaclePasser.get() && mc.player.getEntityPos().length() > 100 && // > 100 check needed bc server sends queue coordinates when joining in first tick causing goal coordinates to be set to (0, 0)
                 (mc.player.getY() < targetY.get() || mc.player.getY() > targetY.get() + 2 || (mc.player.horizontalCollision && !mc.player.collidedSoftly) // collisions / out of highway
                 || (portalTrap != null && portalTrap.getSquaredDistance(mc.player.getBlockPos()) < portalAvoidDistance.get() * portalAvoidDistance.get()) // portal trap detection
                 || waitingForChunksToLoad // waiting for chunks to load
@@ -425,7 +425,7 @@ public class ElytraFlyPlusPlus extends Module {
                 double currDistance = distance.get(); // Keep checking farther distances until a goal is found that has a block beneath it
 
                 if (portalTrap != null) {
-                    currDistance += mc.player.getPos().distanceTo(portalTrap.toCenterPos());
+                    currDistance += mc.player.getEntityPos().distanceTo(portalTrap.toCenterPos());
                     portalTrap = null;
                     info("Pathing around portal.");
                 }
@@ -439,7 +439,7 @@ public class ElytraFlyPlusPlus extends Module {
                         return;
                     }
                     Vec3d unitYawVec = yawToDirection(yaw.get());
-                    Vec3d travelVec = mc.player.getPos().subtract(startPos.get().toCenterPos());
+                    Vec3d travelVec = mc.player.getEntityPos().subtract(startPos.get().toCenterPos());
 
                     double parallelCurrPosDot = travelVec.multiply(new Vec3d(1, 0, 1)).dotProduct(unitYawVec);
                     Vec3d parallelCurrPosComponent = unitYawVec.multiply(parallelCurrPosDot);
@@ -594,7 +594,7 @@ public class ElytraFlyPlusPlus extends Module {
 
         // Check if chunk is on the players path
         Vec3d moveDir = yawToDirection(yaw.get());
-        double distanceToHighway = distancePointToDirection(Vec3d.of(centerPos), moveDir, mc.player.getPos());
+        double distanceToHighway = distancePointToDirection(Vec3d.of(centerPos), moveDir, mc.player.getEntityPos());
 
         if (distanceToHighway > 21) return;
 
@@ -606,7 +606,7 @@ public class ElytraFlyPlusPlus extends Module {
                 {
                     BlockPos position = new BlockPos(pos.x * 16 + x, y, pos.z * 16 + z);
 
-                    if (distancePointToDirection(Vec3d.of(position), moveDir, mc.player.getPos()) > portalScanWidth.get()) continue;
+                    if (distancePointToDirection(Vec3d.of(position), moveDir, mc.player.getEntityPos()) > portalScanWidth.get()) continue;
 
                     if (mc.world.getBlockState(position).getBlock().equals(Blocks.NETHER_PORTAL)) // TODO: This position could be unloaded
                     {

--- a/src/main/java/com/stash/hunt/modules/HighlightOldLava.java
+++ b/src/main/java/com/stash/hunt/modules/HighlightOldLava.java
@@ -246,7 +246,7 @@ public class HighlightOldLava extends Module
                         {
                             if ((logMode.get() == Mode.LogWebhook || logMode.get() == Mode.Both) && !webhookLink.get().isEmpty())
                             {
-                                new Thread(() -> sendWebhook(webhookLink.get(), "Old Chunk Found", "At: " + blockPos.getX() + " " + blockPos.getZ(), (ping.get() ? discordId.get() : null), mc.player.getGameProfile().getName())).start();
+                                new Thread(() -> sendWebhook(webhookLink.get(), "Old Chunk Found", "At: " + blockPos.getX() + " " + blockPos.getZ(), (ping.get() ? discordId.get() : null), mc.player.getGameProfile().name())).start();
                             }
                             if (disconnectOnFound.get()) mc.player.networkHandler.onDisconnect(new DisconnectS2CPacket(Text.literal("[HighlightOldLava] Old lava was found.")));
                             oldLava.add(blockPos);

--- a/src/main/java/com/stash/hunt/modules/OldChunkNotifier.java
+++ b/src/main/java/com/stash/hunt/modules/OldChunkNotifier.java
@@ -219,7 +219,7 @@ public class OldChunkNotifier extends Module {
                 String finalMessage = message; // must be final for thread operations
                 // use threads so if a ton of chunks come at once it doesnt lag the game
                 String discordID = !ping.get() || discordId.get().isBlank() ? null : discordId.get();
-                new Thread(() -> sendWebhook(webhookLink.get(), "Old Chunk Detected", finalMessage + " at " + mc.player.getPos().toString(), discordID, mc.player.getGameProfile().getName())).start();
+                new Thread(() -> sendWebhook(webhookLink.get(), "Old Chunk Detected", finalMessage + " at " + mc.player.getEntityPos().toString(), discordID, mc.player.getGameProfile().name())).start();
             }
         }
 
@@ -238,7 +238,7 @@ public class OldChunkNotifier extends Module {
                 if (logType.get() == LogType.Both || logType.get() == LogType.Webhook)
                 {
                     String discordID = !ping.get() || discordId.get().isBlank() ? null : discordId.get();
-                    new Thread(() -> sendWebhook(webhookLink.get(), "Old Chunk Detected", "Old chunk detected off the highway at " + chunkPos.x * 16 + " " + chunkPos.z * 16, discordID, mc.player.getGameProfile().getName())).start();
+                    new Thread(() -> sendWebhook(webhookLink.get(), "Old Chunk Detected", "Old chunk detected off the highway at " + chunkPos.x * 16 + " " + chunkPos.z * 16, discordID, mc.player.getGameProfile().name())).start();
                 }
             }
         }

--- a/src/main/java/com/stash/hunt/modules/TrailFollower.java
+++ b/src/main/java/com/stash/hunt/modules/TrailFollower.java
@@ -365,7 +365,7 @@ public class TrailFollower extends Module
                 }
                 // set original pos to pathDistance blocks in the direction the player is facing
                 Vec3d offset = (new Vec3d(Math.sin(-mc.player.getYaw() * Math.PI / 180), 0, Math.cos(-mc.player.getYaw() * Math.PI / 180)).normalize()).multiply(pathDistance.get());
-                Vec3d targetPos = mc.player.getPos().add(offset);
+                Vec3d targetPos = mc.player.getEntityPos().add(offset);
                 for (int i = 0; i < (maxTrailLength.get() * startDirectionWeighting.get()); i++)
                 {
                     trail.add(targetPos);
@@ -516,10 +516,10 @@ public class TrailFollower extends Module
                             Vec3d baritoneTarget;
                             if (netherPathMode.get() == NetherPathMode.AVERAGE) {
                                 Vec3d averagePos = calculateAveragePosition(trail);
-                                Vec3d directionVec = averagePos.subtract(mc.player.getPos()).normalize();
-                                Vec3d predictedPos = mc.player.getPos().add(directionVec.multiply(10));
+                                Vec3d directionVec = averagePos.subtract(mc.player.getEntityPos()).normalize();
+                                Vec3d predictedPos = mc.player.getEntityPos().add(directionVec.multiply(10));
                                 targetYaw = Rotations.getYaw(predictedPos);
-                                baritoneTarget = positionInDirection(mc.player.getPos(), targetYaw, pathDistanceActual);
+                                baritoneTarget = positionInDirection(mc.player.getEntityPos(), targetYaw, pathDistanceActual);
                             } else {
                                 Vec3d lastPos = trail.getLast();
                                 baritoneTarget = lastPos;
@@ -530,7 +530,7 @@ public class TrailFollower extends Module
                         }
                     } else {
                         // use average path for overworld
-                        Vec3d targetPos = positionInDirection(mc.player.getPos(), targetYaw, pathDistanceActual);
+                        Vec3d targetPos = positionInDirection(mc.player.getEntityPos(), targetYaw, pathDistanceActual);
                         BaritoneAPI.getProvider().getPrimaryBaritone().getCustomGoalProcess().setGoalAndPath(new GoalXZ((int) targetPos.x, (int) targetPos.z));
 
                         targetYaw = Rotations.getYaw(targetPos); // smooth rotation target
@@ -557,7 +557,7 @@ public class TrailFollower extends Module
     private void onRender(Render3DEvent event)
     {
         if (!debug.get()) return;
-        Vec3d targetPos = positionInDirection(mc.player.getPos(), targetYaw, 10);
+        Vec3d targetPos = positionInDirection(mc.player.getEntityPos(), targetYaw, 10);
         // target line
         event.renderer.line(mc.player.getX(), mc.player.getY(), mc.player.getZ(), targetPos.x, targetPos.y, targetPos.z, new Color(255, 0, 0));
         // chunk
@@ -672,8 +672,8 @@ public class TrailFollower extends Module
         if (!trail.isEmpty()) {
             if (followMode == FollowMode.YAWLOCK) {
                 Vec3d averagePos = calculateAveragePosition(trail);
-                Vec3d positionVec = averagePos.subtract(mc.player.getPos()).normalize();
-                Vec3d targetPos = mc.player.getPos().add(positionVec.multiply(10));
+                Vec3d positionVec = averagePos.subtract(mc.player.getEntityPos()).normalize();
+                Vec3d targetPos = mc.player.getEntityPos().add(positionVec.multiply(10));
                 targetYaw = Rotations.getYaw(targetPos);
             } else {
                 Vec3d lastTrailPoint = trail.getLast();
@@ -730,7 +730,7 @@ public class TrailFollower extends Module
         info(message);
         if (!webhookLink.get().isEmpty())
         {
-            sendWebhook(webhookLink.get(), "TrailFollower", message, null, mc.player.getGameProfile().getName());
+            sendWebhook(webhookLink.get(), "TrailFollower", message, null, mc.player.getGameProfile().name());
         }
     }
 

--- a/src/main/java/com/stash/hunt/modules/TrailMaker.java
+++ b/src/main/java/com/stash/hunt/modules/TrailMaker.java
@@ -123,7 +123,7 @@ public class TrailMaker extends Module
             float targetYaw = (float) Rotations.getYaw(centerBlockPos);
             mc.player.setYaw(Utils.smoothRotation(mc.player.getYaw(), targetYaw, rotationScaling.get()));
 
-            if (mc.player.getPos().squaredDistanceTo(centerBlockPos) < 16 * 16)
+            if (mc.player.getEntityPos().squaredDistanceTo(centerBlockPos) < 16 * 16)
             {
                 ChunkPos point = points.poll();
                 ModuleManager.getModule(Drawing.class).drawingCache.removeHighlight(point.x, point.z, dimension);


### PR DESCRIPTION
- Update gradle.properties with 1.21.10 versions
- Update GitHub workflow to build for Minecraft 1.21.10
- Apply Minecraft 1.21.10 API breaking changes:
  * Replace mc.player.getPos() with mc.player.getEntityPos()
  * Replace GameProfile.getName() with GameProfile.name()
  * Replace GameProfile.getId() with GameProfile.id()